### PR TITLE
詳細ページがない場合はAmazonに直接遷移する

### DIFF
--- a/src/components/EditorialDepartmentRecommendationsBox.jsx
+++ b/src/components/EditorialDepartmentRecommendationsBox.jsx
@@ -16,7 +16,7 @@ const EditorialDepartmentRecommendationsBox = function (props) {
         `${process.env.REACT_APP_HOST}/details/${ranking.asin}`
       );
     }
-    return '#!';
+    return `https://amazon.co.jp/dp/${ranking.asin}`;
   };
 
   const awardChecker = (ranking) => {


### PR DESCRIPTION
## 関連issue
#12 

## 概要
詳細ページがない場合はAmazonに直接遷移するよう変更した。